### PR TITLE
Replace drem() by remainder() for portability.

### DIFF
--- a/geometry/s1angle.cc
+++ b/geometry/s1angle.cc
@@ -25,7 +25,7 @@ S1Angle S1Angle::Normalized() const {
 }
 
 void S1Angle::Normalize() {
-  radians_ = drem(radians_, 2.0 * M_PI);
+  radians_ = remainder(radians_, 2.0 * M_PI);
   if (radians_ <= -M_PI) radians_ = M_PI;
 }
 

--- a/geometry/s1interval.cc
+++ b/geometry/s1interval.cc
@@ -110,7 +110,7 @@ bool S1Interval::InteriorIntersects(S1Interval const& y) const {
 
 inline static double PositiveDistance(double a, double b) {
   // Compute the distance from "a" to "b" in the range [0, 2*Pi).
-  // This is equivalent to (drem(b - a - M_PI, 2 * M_PI) + M_PI),
+  // This is equivalent to (remainder(b - a - M_PI, 2 * M_PI) + M_PI),
   // except that it is more numerically stable (it does not lose
   // precision for very small positive distances).
   double d = b - a;
@@ -180,7 +180,7 @@ S1Interval S1Interval::Expanded(double radius) const {
   // for a 1-bit rounding error when computing each endpoint.
   if (GetLength() + 2 * radius >= 2 * M_PI - 1e-15) return Full();
 
-  S1Interval result(drem(lo() - radius, 2*M_PI), drem(hi() + radius, 2*M_PI));
+  S1Interval result(remainder(lo() - radius, 2*M_PI), remainder(hi() + radius, 2*M_PI));
   if (result.lo() <= -M_PI) result.set_lo(M_PI);
   return result;
 }
@@ -245,6 +245,6 @@ S1Interval S1Interval::Intersection(S1Interval const& y) const {
 bool S1Interval::ApproxEquals(S1Interval const& y, double max_error) const {
   if (is_empty()) return y.GetLength() <= max_error;
   if (y.is_empty()) return GetLength() <= max_error;
-  return (fabs(drem(y.lo() - lo(), 2 * M_PI)) +
-          fabs(drem(y.hi() - hi(), 2 * M_PI))) <= max_error;
+  return (fabs(remainder(y.lo() - lo(), 2 * M_PI)) +
+          fabs(remainder(y.hi() - hi(), 2 * M_PI))) <= max_error;
 }

--- a/geometry/s2cap.cc
+++ b/geometry/s2cap.cc
@@ -153,8 +153,8 @@ S2LatLngRect S2Cap::GetRectBound() const {
     double sin_c = cos(axis_ll.lat().radians());
     if (sin_a <= sin_c) {
       double angle_A = asin(sin_a / sin_c);
-      lng[0] = drem(axis_ll.lng().radians() - angle_A, 2 * M_PI);
-      lng[1] = drem(axis_ll.lng().radians() + angle_A, 2 * M_PI);
+      lng[0] = remainder(axis_ll.lng().radians() - angle_A, 2 * M_PI);
+      lng[1] = remainder(axis_ll.lng().radians() + angle_A, 2 * M_PI);
     }
   }
   return S2LatLngRect(R1Interval(lat[0], lat[1]),

--- a/geometry/s2latlng.cc
+++ b/geometry/s2latlng.cc
@@ -5,10 +5,10 @@
 #include "s2latlng.h"
 
 S2LatLng S2LatLng::Normalized() const {
-  // drem(x, 2 * M_PI) reduces its argument to the range [-M_PI, M_PI]
+  // remainder(x, 2 * M_PI) reduces its argument to the range [-M_PI, M_PI]
   // inclusive, which is what we want here.
   return S2LatLng(max(-M_PI_2, min(M_PI_2, lat().radians())),
-                  drem(lng().radians(), 2 * M_PI));
+                  remainder(lng().radians(), 2 * M_PI));
 }
 
 S2Point S2LatLng::ToPoint() const {

--- a/geometry/s2latlngrect.cc
+++ b/geometry/s2latlngrect.cc
@@ -171,7 +171,7 @@ S2Cap S2LatLngRect::GetCapBound() const {
   // rectangles that are larger than 180 degrees, we punt and always return a
   // bounding cap centered at one of the two poles.
   double lng_span = lng_.hi() - lng_.lo();
-  if (drem(lng_span, 2 * M_PI) >= 0) {
+  if (remainder(lng_span, 2 * M_PI) >= 0) {
     if (lng_span < 2 * M_PI) {
       S2Cap mid_cap = S2Cap::FromAxisAngle(GetCenter().ToPoint(),
                                            S1Angle::Radians(0));


### PR DESCRIPTION
The function drem() is not recognised on Windows using MinGW g++.