### PR TITLE
Update travis script to handle openssl on osx.

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -1,6 +1,11 @@
 #!/bin/sh -x
 # Continuous integration script for Travis
 
+# Add flags for openssl on osx
+if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
+  export OPENSSL_ROOT_DIR="/usr/local/opt/openssl"
+fi
+
 # Build the library and install it.
 echo "## Building and installing libs2..."
 cd geometry


### PR DESCRIPTION
This change to the travis script should make the library compile with openssl on osx again.

Python tests are still failing, but that seems to be a different issue related to using homebrew python or the system python. I don't have much python experience so I can't be of much help there.