### PR TITLE
Openssl 1.1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,21 @@ matrix:
       dist: trusty
     - os: osx
       compiler: clang
+      env: OPENSSL1.1=false
+    - os: osx
+      compiler: clang
+      env: OPENSSL1.1=true
 
 before_install:
 - |
-  if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+  if [[ "${TRAVIS_OS_NAME}" == "osx" && OPENSSL1.1 == "false" ]]; then
+    brew update
+    brew install swig
+    brew outdated openssl || brew upgrade openssl
+    brew outdated cmake || brew upgrade cmake
+  fi
+- |
+  if [[ "${TRAVIS_OS_NAME}" == "osx" && OPENSSL1.1 == "true" ]]; then
     brew update
     brew install swig
     brew outdated openssl || brew upgrade openssl

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,21 +23,21 @@ matrix:
       dist: trusty
     - os: osx
       compiler: clang
-      env: OPENSSL1.1=false
+      env: OPENSSL_VER="1.0"
     - os: osx
       compiler: clang
-      env: OPENSSL1.1=true
+      env: OPENSSL_VER="1.1"
 
 before_install:
 - |
-  if [[ "${TRAVIS_OS_NAME}" == "osx" && OPENSSL1.1 == "false" ]]; then
+  if [[ "${TRAVIS_OS_NAME}" == "osx" && OPENSSL_VER == "1.0" ]]; then
     brew update
     brew install swig
     brew outdated openssl || brew upgrade openssl
     brew outdated cmake || brew upgrade cmake
   fi
 - |
-  if [[ "${TRAVIS_OS_NAME}" == "osx" && OPENSSL1.1 == "true" ]]; then
+  if [[ "${TRAVIS_OS_NAME}" == "osx" && OPENSSL_VER == "1.1" ]]; then
     brew update
     brew install swig
     brew outdated openssl@1.1 || brew upgrade openssl@1.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   if [[ "${TRAVIS_OS_NAME}" == "osx" && OPENSSL1.1 == "true" ]]; then
     brew update
     brew install swig
-    brew outdated openssl || brew upgrade openssl
+    brew outdated openssl@1.1 || brew upgrade openssl@1.1
     brew outdated cmake || brew upgrade cmake
   fi
 - python -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
   if [[ "${TRAVIS_OS_NAME}" == "osx" && "${OPENSSL_VER}" == "1.1" ]]; then
     brew update
     brew install swig
-    brew outdated openssl@1.1 || brew upgrade openssl@1.1
+    brew install openssl@1.1
     brew outdated cmake || brew upgrade cmake
   fi
 - python -V

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,14 +30,14 @@ matrix:
 
 before_install:
 - |
-  if [[ "${TRAVIS_OS_NAME}" == "osx" && OPENSSL_VER == "1.0" ]]; then
+  if [[ "${TRAVIS_OS_NAME}" == "osx" && "${OPENSSL_VER}" == "1.0" ]]; then
     brew update
     brew install swig
     brew outdated openssl || brew upgrade openssl
     brew outdated cmake || brew upgrade cmake
   fi
 - |
-  if [[ "${TRAVIS_OS_NAME}" == "osx" && OPENSSL_VER == "1.1" ]]; then
+  if [[ "${TRAVIS_OS_NAME}" == "osx" && "${OPENSSL_VER}" == "1.1" ]]; then
     brew update
     brew install swig
     brew outdated openssl@1.1 || brew upgrade openssl@1.1

--- a/geometry/util/math/exactfloat/exactfloat.cc
+++ b/geometry/util/math/exactfloat/exactfloat.cc
@@ -87,11 +87,11 @@ static int BN_ext_count_low_zero_bits(const BIGNUM* bn) {
 }
 
 ExactFloat::ExactFloat(double v) {
-  BN_init(&bn_);
+  bn_ = BN_new();
   sign_ = signbit(v) ? -1 : 1;
-  if (isnan(v)) {
+  if (std::isnan(v)) {
     set_nan();
-  } else if (isinf(v)) {
+  } else if (std::isinf(v)) {
     set_inf(sign_);
   } else {
     // The following code is much simpler than messing about with bit masks,
@@ -103,18 +103,18 @@ ExactFloat::ExactFloat(double v) {
     int exp;
     double f = frexp(fabs(v), &exp);
     uint64 m = static_cast<uint64>(ldexp(f, kDoubleMantissaBits));
-    BN_ext_set_uint64(&bn_, m);
+    BN_ext_set_uint64(bn_, m);
     bn_exp_ = exp - kDoubleMantissaBits;
     Canonicalize();
   }
 }
 
 ExactFloat::ExactFloat(int v) {
-  BN_init(&bn_);
+  bn_ = BN_new();
   sign_ = (v >= 0) ? 1 : -1;
   // Note that this works even for INT_MIN because the parameter type for
   // BN_set_word() is unsigned.
-  CHECK(BN_set_word(&bn_, abs(v)));
+  CHECK(BN_set_word(bn_, abs(v)));
   bn_exp_ = 0;
   Canonicalize();
 }
@@ -122,8 +122,8 @@ ExactFloat::ExactFloat(int v) {
 ExactFloat::ExactFloat(const ExactFloat& b)
     : sign_(b.sign_),
       bn_exp_(b.bn_exp_) {
-  BN_init(&bn_);
-  BN_copy(&bn_, &b.bn_);
+  bn_ = BN_new();
+  BN_copy(bn_, b.bn_);
 }
 
 ExactFloat ExactFloat::SignedZero(int sign) {
@@ -145,30 +145,30 @@ ExactFloat ExactFloat::NaN() {
 }
 
 int ExactFloat::prec() const {
-  return BN_num_bits(&bn_);
+  return BN_num_bits(bn_);
 }
 
 int ExactFloat::exp() const {
   DCHECK(is_normal());
-  return bn_exp_ + BN_num_bits(&bn_);
+  return bn_exp_ + BN_num_bits(bn_);
 }
 
 void ExactFloat::set_zero(int sign) {
   sign_ = sign;
   bn_exp_ = kExpZero;
-  if (!BN_is_zero(&bn_)) BN_zero(&bn_);
+  if (!BN_is_zero(bn_)) BN_zero(bn_);
 }
 
 void ExactFloat::set_inf(int sign) {
   sign_ = sign;
   bn_exp_ = kExpInfinity;
-  if (!BN_is_zero(&bn_)) BN_zero(&bn_);
+  if (!BN_is_zero(bn_)) BN_zero(bn_);
 }
 
 void ExactFloat::set_nan() {
   sign_ = 1;
   bn_exp_ = kExpNaN;
-  if (!BN_is_zero(&bn_)) BN_zero(&bn_);
+  if (!BN_is_zero(bn_)) BN_zero(bn_);
 }
 
 double ExactFloat::ToDouble() const {
@@ -182,13 +182,13 @@ double ExactFloat::ToDouble() const {
 }
 
 double ExactFloat::ToDoubleHelper() const {
-  DCHECK_LE(BN_num_bits(&bn_), kDoubleMantissaBits);
+  DCHECK_LE(BN_num_bits(bn_), kDoubleMantissaBits);
   if (!is_normal()) {
     if (is_zero()) return copysign(0, sign_);
     if (is_inf()) return copysign(INFINITY, sign_);
     return copysign(NAN, sign_);
   }
-  uint64 d_mantissa = BN_ext_get_uint64(&bn_);
+  uint64 d_mantissa = BN_ext_get_uint64(bn_);
   // We rely on ldexp() to handle overflow and underflow.  (It will return a
   // signed zero or infinity if the result is too small or too large.)
   return sign_ * ldexp(static_cast<double>(d_mantissa), bn_exp_);
@@ -239,11 +239,11 @@ ExactFloat ExactFloat::RoundToPowerOf2(int bit_exp, RoundingMode mode) const {
     // Never increment.
   } else if (mode == kRoundTiesAwayFromZero) {
     // Increment if the highest discarded bit is 1.
-    if (BN_is_bit_set(&bn_, shift - 1))
+    if (BN_is_bit_set(bn_, shift - 1))
       increment = true;
   } else if (mode == kRoundAwayFromZero) {
     // Increment unless all discarded bits are zero.
-    if (BN_ext_count_low_zero_bits(&bn_) < shift)
+    if (BN_ext_count_low_zero_bits(bn_) < shift)
       increment = true;
   } else {
     DCHECK_EQ(mode, kRoundTiesToEven);
@@ -253,16 +253,16 @@ ExactFloat ExactFloat::RoundToPowerOf2(int bit_exp, RoundingMode mode) const {
     //    0/10*       ->    Don't increment (fraction = 1/2, kept part even)
     //    1/10*       ->    Increment (fraction = 1/2, kept part odd)
     //    ./1.*1.*    ->    Increment (fraction > 1/2)
-    if (BN_is_bit_set(&bn_, shift - 1) &&
-        ((BN_is_bit_set(&bn_, shift) ||
-          BN_ext_count_low_zero_bits(&bn_) < shift - 1))) {
+    if (BN_is_bit_set(bn_, shift - 1) &&
+        ((BN_is_bit_set(bn_, shift) ||
+          BN_ext_count_low_zero_bits(bn_) < shift - 1))) {
       increment = true;
     }
   }
   r.bn_exp_ = bn_exp_ + shift;
-  CHECK(BN_rshift(&r.bn_, &bn_, shift));
+  CHECK(BN_rshift(r.bn_, bn_, shift));
   if (increment) {
-    CHECK(BN_add_word(&r.bn_, 1));
+    CHECK(BN_add_word(r.bn_, 1));
   }
   r.sign_ = sign_;
   r.Canonicalize();
@@ -369,7 +369,7 @@ int ExactFloat::GetDecimalDigits(int max_digits, string* digits) const {
   int bn_exp10;
   if (bn_exp_ >= 0) {
     // The easy case: bn = bn_ * (2 ** bn_exp_)), bn_exp10 = 0.
-    CHECK(BN_lshift(bn, &bn_, bn_exp_));
+    CHECK(BN_lshift(bn, bn_, bn_exp_));
     bn_exp10 = 0;
   } else {
     // Set bn = bn_ * (5 ** -bn_exp_) and bn_exp10 = bn_exp_.  This is
@@ -379,7 +379,7 @@ int ExactFloat::GetDecimalDigits(int max_digits, string* digits) const {
     CHECK(BN_set_word(bn, 5));
     BN_CTX* ctx = BN_CTX_new();
     CHECK(BN_exp(bn, bn, power, ctx));
-    CHECK(BN_mul(bn, bn, &bn_, ctx));
+    CHECK(BN_mul(bn, bn, bn_, ctx));
     BN_CTX_free(ctx);
     BN_free(power);
     bn_exp10 = bn_exp_;
@@ -435,7 +435,7 @@ ExactFloat& ExactFloat::operator=(const ExactFloat& b) {
   if (this != &b) {
     sign_ = b.sign_;
     bn_exp_ = b.bn_exp_;
-    BN_copy(&bn_, &b.bn_);
+    BN_copy(bn_, b.bn_);
   }
   return *this;
 }
@@ -482,24 +482,24 @@ ExactFloat ExactFloat::SignedSum(int a_sign, const ExactFloat* a,
   // Shift "a" if necessary so that both values have the same bn_exp_.
   ExactFloat r;
   if (a->bn_exp_ > b->bn_exp_) {
-    CHECK(BN_lshift(&r.bn_, &a->bn_, a->bn_exp_ - b->bn_exp_));
+    CHECK(BN_lshift(r.bn_, a->bn_, a->bn_exp_ - b->bn_exp_));
     a = &r;  // The only field of "a" used below is bn_.
   }
   r.bn_exp_ = b->bn_exp_;
   if (a_sign == b_sign) {
-    CHECK(BN_add(&r.bn_, &a->bn_, &b->bn_));
+    CHECK(BN_add(r.bn_, a->bn_, b->bn_));
     r.sign_ = a_sign;
   } else {
     // Note that the BIGNUM documentation is out of date -- all methods now
     // allow the result to be the same as any input argument, so it is okay if
     // (a == &r) due to the shift above.
-    CHECK(BN_sub(&r.bn_, &a->bn_, &b->bn_));
-    if (BN_is_zero(&r.bn_)) {
+    CHECK(BN_sub(r.bn_, a->bn_, b->bn_));
+    if (BN_is_zero(r.bn_)) {
       r.sign_ = +1;
-    } else if (BN_is_negative(&r.bn_)) {
+    } else if (BN_is_negative(r.bn_)) {
       // The magnitude of "b" was larger.
       r.sign_ = b_sign;
-      BN_set_negative(&r.bn_, false);
+      BN_set_negative(r.bn_, false);
     } else {
       // They were equal, or the magnitude of "a" was larger.
       r.sign_ = a_sign;
@@ -515,16 +515,16 @@ void ExactFloat::Canonicalize() {
   // Underflow/overflow occurs if exp() is not in [kMinExp, kMaxExp].
   // We also convert a zero mantissa to signed zero.
   int my_exp = exp();
-  if (my_exp < kMinExp || BN_is_zero(&bn_)) {
+  if (my_exp < kMinExp || BN_is_zero(bn_)) {
     set_zero(sign_);
   } else if (my_exp > kMaxExp) {
     set_inf(sign_);
-  } else if (!BN_is_odd(&bn_)) {
+  } else if (!BN_is_odd(bn_)) {
     // Remove any low-order zero bits from the mantissa.
-    DCHECK(!BN_is_zero(&bn_));
-    int shift = BN_ext_count_low_zero_bits(&bn_);
+    DCHECK(!BN_is_zero(bn_));
+    int shift = BN_ext_count_low_zero_bits(bn_);
     if (shift > 0) {
-      CHECK(BN_rshift(&bn_, &bn_, shift));
+      CHECK(BN_rshift(bn_, bn_, shift));
       bn_exp_ += shift;
     }
   }
@@ -557,7 +557,7 @@ ExactFloat operator*(const ExactFloat& a, const ExactFloat& b) {
   r.sign_ = result_sign;
   r.bn_exp_ = a.bn_exp_ + b.bn_exp_;
   BN_CTX* ctx = BN_CTX_new();
-  CHECK(BN_mul(&r.bn_, &a.bn_, &b.bn_, ctx));
+  CHECK(BN_mul(r.bn_, a.bn_, b.bn_, ctx));
   BN_CTX_free(ctx);
   r.Canonicalize();
   return r;
@@ -576,14 +576,14 @@ bool operator==(const ExactFloat& a, const ExactFloat& b) {
 
   // Otherwise, the signs and mantissas must match.  Note that non-normal
   // values such as infinity have a mantissa of zero.
-  return a.sign_ == b.sign_ && BN_ucmp(&a.bn_, &b.bn_) == 0;
+  return a.sign_ == b.sign_ && BN_ucmp(a.bn_, b.bn_) == 0;
 }
 
 int ExactFloat::ScaleAndCompare(const ExactFloat& b) const {
   DCHECK(is_normal() && b.is_normal() && bn_exp_ >= b.bn_exp_);
   ExactFloat tmp = *this;
-  CHECK(BN_lshift(&tmp.bn_, &tmp.bn_, bn_exp_ - b.bn_exp_));
-  return BN_ucmp(&tmp.bn_, &b.bn_);
+  CHECK(BN_lshift(tmp.bn_, tmp.bn_, bn_exp_ - b.bn_exp_));
+  return BN_ucmp(tmp.bn_, b.bn_);
 }
 
 bool ExactFloat::UnsignedLess(const ExactFloat& b) const {
@@ -674,7 +674,7 @@ T ExactFloat::ToInteger(RoundingMode mode) const {
   if (!r.is_inf()) {
     // If the unsigned value has more than 63 bits it is always clamped.
     if (r.exp() < 64) {
-      int64 value = BN_ext_get_uint64(&r.bn_) << r.bn_exp_;
+      int64 value = BN_ext_get_uint64(r.bn_) << r.bn_exp_;
       if (r.sign_ < 0) value = -value;
       return max(kMinValue, min(kMaxValue, value));
     }

--- a/geometry/util/math/exactfloat/exactfloat.h
+++ b/geometry/util/math/exactfloat/exactfloat.h
@@ -98,6 +98,7 @@
 #include <limits.h>
 #include <iostream>
 using std::ostream;
+using std::cout;
 using std::endl;
 
 #include <string>

--- a/geometry/util/math/exactfloat/exactfloat.h
+++ b/geometry/util/math/exactfloat/exactfloat.h
@@ -98,7 +98,6 @@
 #include <limits.h>
 #include <iostream>
 using std::ostream;
-using std::cout;
 using std::endl;
 
 #include <string>
@@ -500,7 +499,7 @@ class ExactFloat {
   //  - bn_exp_ is the base-2 exponent applied to bn_.
   int32 sign_;
   int32 bn_exp_;
-  BIGNUM bn_;
+  BIGNUM* bn_;
 
   // A standard IEEE "double" has a 53-bit mantissa consisting of a 52-bit
   // fraction plus an implicit leading "1" bit.
@@ -560,11 +559,11 @@ class ExactFloat {
 // Implementation details follow:
 
 inline ExactFloat::ExactFloat() : sign_(1), bn_exp_(kExpZero) {
-  BN_init(&bn_);
+  bn_ = BN_new();
 }
 
 inline ExactFloat::~ExactFloat() {
-  BN_free(&bn_);
+  BN_free(bn_);
 }
 
 inline bool ExactFloat::is_zero() const { return bn_exp_ == kExpZero; }

--- a/travis.sh
+++ b/travis.sh
@@ -4,6 +4,9 @@
 # Add flags for openssl and Python on osx
 if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
 	export OPENSSL_ROOT_DIR="/usr/local/opt/openssl"
+    if [ "${OPENSSL_VER}" == "1.1" ]; then
+	    export OPENSSL_ROOT_DIR="/usr/local/opt/openssl@1.1"
+    fi
 	export PATH="/usr/bin:${PATH}"
 fi
 


### PR DESCRIPTION
The new version of OpenSSL (1.1) removed `BN_init()`, so the s2-geometry library doesn't compile against that. I have updated the code to work with OpenSSL 1.1. Apart from replacing `BN_init` with `BN_new` etc. two functions needed to be rewritten:

- `BN_ext_get_uint64`
- `BN_ext_count_low_zero_bits`

The old code accessed internal data structures in a BIGNUM which is no longer allowed. My reimplementations are probably a lot slower, but I haven't tested it.

If you accept this pull request please squash all commits into one since there are a bunch of commits related to my bad attempts at making travis compile against OpenSSL 1.1.